### PR TITLE
Google Interstitial ads promoting a SwiftUI iOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# SwiftUI-Ads-Demo
-A simple SwiftUI demo app demonstrating banner ads, interstitial ads, and rewarded ads integration with Google AdMob.

--- a/SwiftUI-Interstitial-Ads-POC/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SwiftUI-Interstitial-Ads-POC/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI-Interstitial-Ads-POC/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwiftUI-Interstitial-Ads-POC/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI-Interstitial-Ads-POC/Assets.xcassets/Contents.json
+++ b/SwiftUI-Interstitial-Ads-POC/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI-Interstitial-Ads-POC/ContentView.swift
+++ b/SwiftUI-Interstitial-Ads-POC/ContentView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+extension UIApplication {
+    static var rootController: UIViewController? {
+        return UIApplication.shared
+            .connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }?
+            .rootViewController
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var adViewModel = InterstitialViewModel()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Interstitial Ad Demo")
+                .font(.title)
+            Button("Show Interstitial Ad") {
+                if let root = UIApplication.rootController, adViewModel.adLoaded {
+                    adViewModel.showAd(from: root)
+                }
+            }
+            .disabled(!adViewModel.adLoaded)
+        }
+        .onAppear {
+            adViewModel.loadAd()
+        }
+        .padding()
+    }
+} 

--- a/SwiftUI-Interstitial-Ads-POC/Info.plist
+++ b/SwiftUI-Interstitial-Ads-POC/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AVGameBypassSystemSpatialAudio</key>
+	<false/>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
+	<key>SKAdNetworkItems</key>
+	<array>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>cstr6suwn9.skadnetwork</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SwiftUI-Interstitial-Ads-POC/InterstitialAdView.swift
+++ b/SwiftUI-Interstitial-Ads-POC/InterstitialAdView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import GoogleMobileAds
+
+class InterstitialAdManager: NSObject, ObservableObject {
+    @Published var interstitial: InterstitialAd?
+    @Published var isLoading = false
+    
+    override init() {
+        super.init()
+        DispatchQueue.main.async { [weak self] in
+            self?.loadInterstitial()
+        }
+    }
+    
+    func loadInterstitial() {
+        guard !isLoading else { return }
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.isLoading = true
+        }
+        
+        let request = Request()
+        InterstitialAd.load(with: "ca-app-pub-3940256099942544/4411468910", request: request) { [weak self] ad, error in
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                if let error = error {
+                    print("Failed to load interstitial ad with error: \(error.localizedDescription)")
+                    return
+                }
+                self?.interstitial = ad
+                print("Ad loaded successfully")
+            }
+        }
+    }
+    
+    func showAd(from rootViewController: UIViewController) {
+        guard let interstitial = interstitial else {
+            print("Ad wasn't ready")
+            loadInterstitial()
+            return
+        }
+        
+        // Set up the delegate to handle ad dismissal
+        interstitial.fullScreenContentDelegate = self
+        
+        // Present the ad
+        interstitial.present(from: rootViewController)
+        
+        // Clear the current ad
+        self.interstitial = nil
+        
+        // Load the next ad
+        loadInterstitial()
+    }
+}
+
+// MARK: - GADFullScreenContentDelegate
+extension InterstitialAdManager: FullScreenContentDelegate {
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        print("Ad dismissed")
+        loadInterstitial()
+    }
+    
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        print("Ad failed to present with error: \(error.localizedDescription)")
+        loadInterstitial()
+    }
+    
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
+        print("Ad will present")
+    }
+}
+
+struct InterstitialAdView: UIViewControllerRepresentable {
+    @ObservedObject var adManager: InterstitialAdManager
+    
+    func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = UIViewController()
+        return viewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        adManager.showAd(from: uiViewController)
+    }
+} 

--- a/SwiftUI-Interstitial-Ads-POC/InterstitialViewModel.swift
+++ b/SwiftUI-Interstitial-Ads-POC/InterstitialViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+import GoogleMobileAds
+
+class InterstitialViewModel: NSObject, ObservableObject, FullScreenContentDelegate {
+    private var interstitialAd: InterstitialAd?
+    @Published var adLoaded = false
+
+    func loadAd() {
+        let request = Request()
+        InterstitialAd.load(with: "ca-app-pub-3940256099942544/4411468910", request: request) { [weak self] ad, error in
+            if let error = error {
+                print("Failed to load interstitial ad: \(error.localizedDescription)")
+                self?.adLoaded = false
+                return
+            }
+            self?.interstitialAd = ad
+            self?.interstitialAd?.fullScreenContentDelegate = self
+            self?.adLoaded = true
+        }
+    }
+
+    func showAd(from root: UIViewController) {
+        guard let ad = interstitialAd else {
+            print("Ad wasn't ready")
+            return
+        }
+        ad.present(from: root)
+    }
+
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        interstitialAd = nil
+        adLoaded = false
+        loadAd()
+    }
+} 

--- a/SwiftUI-Interstitial-Ads-POC/README.md
+++ b/SwiftUI-Interstitial-Ads-POC/README.md
@@ -1,0 +1,111 @@
+# SwiftUI Interstitial ads POC
+
+This project demonstrates the integration of Google Mobile Ads in a SwiftUI application.
+
+Interstitial ads are full-screen ads that cover the interface of an app until closed by the user. They're typically displayed at natural transition points in the flow of an app, such as between activities or during the pause between levels in a game. When an app shows an interstitial ad, the user has the choice to either tap on the ad and continue to its destination or close it and return to the app.
+
+## Setup Instructions
+
+1. **Google Mobile Ads SDK**
+   - The project uses Google Mobile Ads SDK via Swift Package Manager
+   - Package URL: `https://github.com/googleads/swift-package-manager-google-mobile-ads.git`
+
+2. **Ad Unit IDs**
+   - Current implementation uses test ad unit IDs
+   - Interstitial Ad Test ID: `ca-app-pub-3940256099942544/4411468910`
+   - App ID: `ca-app-pub-3940256099942544~1458002511`
+
+3. **Production Setup**
+   - Replace test ad unit IDs with your actual AdMob ad unit IDs
+   - Update the `GADApplicationIdentifier` in Info.plist with your actual AdMob app ID
+   - Ensure you have an active AdMob account
+
+## Implementation Details
+
+- Interstitial ads are implemented using `InterstitialAdView` and `InterstitialAdManager`
+- Ads are initialized in `SwiftUI_Ads_POCApp`
+- Interstitial ads are shown when the user taps the "Show Interstitial Ad" button
+
+
+
+## Project Creation & Usage
+
+### How this project was created
+
+This project was created as a minimal SwiftUI example for Google AdMob Interstitial Ads, following the official guide: https://developers.google.com/admob/ios/interstitial
+
+- The project uses Swift Package Manager to add the Google Mobile Ads SDK.
+- The main files are:
+  - `ContentView.swift`: The main SwiftUI view.
+  - `InterstitialViewModel.swift`: Handles loading and showing interstitial ads.
+  - `SwiftUI_Ads_POCApp.swift`: The app entry point, initializes GoogleMobileAds.
+  - `Info.plist`: Contains the AdMob App ID and other configuration.
+  - `Assets.xcassets`: App icons and color assets.
+
+### File Descriptions
+
+- **ContentView.swift**: The main SwiftUI view of the app. It provides the user interface, including a button to show an interstitial ad. It uses the InterstitialViewModel to manage ad loading and presentation.
+
+- **InterstitialAdView.swift**: (If present) An alternative or legacy implementation for displaying interstitial ads. You may use this for reference or for custom ad presentation logic. In the minimal setup, this file is not strictly required, but may be included for experimentation or comparison.
+
+- **InterstitialViewModel.swift**: Contains the logic for loading, presenting, and reloading interstitial ads using the Google Mobile Ads SDK. It is an ObservableObject, so it can be used with SwiftUI's data flow. Handles ad lifecycle and delegates.
+
+- **SwiftUI_Ads_POCApp.swift**: The entry point of the SwiftUI app (annotated with @main). It initializes the Google Mobile Ads SDK and sets ContentView as the root view.
+
+- **Info.plist**: The property list file for app configuration. It includes the AdMob App ID (GADApplicationIdentifier) and other required settings for the app to run and for AdMob to function.
+
+- **Assets.xcassets**: Contains image and color assets for the app, such as the app icon and accent color. Required for a complete Xcode project.
+
+
+### How to open this project in Xcode 
+
+1. Open Xcode.
+2. Select "Open a project or file".
+3. Navigate to this folder and select `SwiftUI-Ads-POC.xcodeproj`.
+4. Build and run the project on a simulator or device.
+
+### What to do if SwiftUI-Ads-POC.xcodeproj is missing
+
+If you do not have the `SwiftUI-Ads-POC.xcodeproj` file (the Xcode project file), you can create a new Xcode project and add the existing source files as follows:
+
+1. **Open Xcode** and select "Create a new Xcode project".
+2. Choose **App** under the iOS tab and click **Next**.
+3. Enter the product name (e.g., `SwiftUI-Ads-POC`), select **Swift** as the language, and **SwiftUI** as the interface. Click **Next**.
+4. Choose the folder where your existing files are located and click **Create**.
+5. In the Xcode project navigator, right-click on the project group (usually named after your project) and select **Add Files to "SwiftUI-Ads-POC"...**
+6. Select all your existing Swift files (`ContentView.swift`, `InterstitialViewModel.swift`, `SwiftUI_Ads_POCApp.swift`, etc.), `Info.plist`, and the `Assets.xcassets` folder, then click **Add**.
+7. Make sure all files are added to the correct target (check the Target Membership in the File Inspector for each file).
+8. Add the Google Mobile Ads SDK via Swift Package Manager (File > Add Packages... and use `https://github.com/googleads/swift-package-manager-google-mobile-ads.git`).
+9. Build and run the project.
+
+This will recreate the Xcode project and allow you to use your existing source files.
+
+### Folder Structure
+
+```
+SwiftUI-Ads-POC/
+├── Assets.xcassets/
+│   ├── AccentColor.colorset/
+│   │   └── Contents.json
+│   ├── AppIcon.appiconset/
+│   │   └── Contents.json
+│   ├── Contents.json
+│   └── .DS_Store
+├── ContentView.swift
+├── InterstitialAdView.swift
+├── InterstitialViewModel.swift
+├── Info.plist
+├── README.md
+├── SwiftUI_Ads_POCApp.swift
+└── SwiftUI-Ads-POC.xcodeproj/
+```
+
+For more details, see the [official AdMob iOS interstitial guide](https://developers.google.com/admob/ios/interstitial).
+
+## References
+
+- [Google AdMob iOS Interstitial Guide](https://developers.google.com/admob/ios/interstitial)
+- [Google Mobile Ads SDK for iOS (Swift Package Manager)](https://github.com/googleads/swift-package-manager-google-mobile-ads)
+- Apple Developer Documentation: [SwiftUI](https://developer.apple.com/documentation/swiftui), [UIApplication](https://developer.apple.com/documentation/uikit/uiapplication)
+
+All implementation and setup steps in this project are based on the official AdMob documentation and best practices from Apple and Google. 

--- a/SwiftUI-Interstitial-Ads-POC/SwiftUI_Ads_POCApp.swift
+++ b/SwiftUI-Interstitial-Ads-POC/SwiftUI_Ads_POCApp.swift
@@ -1,0 +1,22 @@
+//
+//  SwiftUI-Ads-POC
+//  SwiftUI-Ads-POC
+//
+//  Created by Anirban Deb on 11/6/25.
+//
+
+import SwiftUI
+import GoogleMobileAds
+
+@main
+struct SwiftUI_Ads_POCApp: App {
+    init() {
+        MobileAds.shared.start(completionHandler: nil)
+    }
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }  
+    }
+}


### PR DESCRIPTION
Interstitial ads are full-screen ads that cover the interface of an app until closed by the user. They're typically displayed at natural transition points in the flow of an app, such as between activities or during the pause between levels in a game. When an app shows an interstitial ad, the user has the choice to either tap on the ad and continue to its destination or close it and return to the app.

**Note**: The [README.md](https://github.com/YamamotoDesu/SwiftUI-Ads-POC/pull/1/commits/c24939c8ec67a7837625035955358a0e4ffab608) file discusses all the setup-related procedures in Xcode. This file has been included in the project folder.

I have included only the necessary files to paste into Xcode. For the full project, please follow the link below.

**### Full Project GitHub Link**
For full content Please follow this branch: https://github.com/YamamotoDesu/SwiftUI-Ads-POC/tree/interstitial-branch-swiftui-ads-v1

### **Important**
### In Xcode edit Info Update:

1. key: GameBypassSystemSpatialAudio type: Boolean value: false
2. key: GADApplicationIdentifier type:String value: ca-app-pub-3940256099942544~1458002511
3. key: SKAdNetworkItems type: Array [key: SKAdNetworkIdentifier type:String value: cstr6suwn9.skadnetwork


<img width="1383" alt="Info" src="https://github.com/user-attachments/assets/b75191da-ee45-4d22-a34b-6d0b7b92bc2e" />

### OutPut Image

![Screenshot 2025-06-20 at 10 04 06 PM](https://github.com/user-attachments/assets/7f600bc5-30b0-4a09-8c10-c8b528f8bd91)

